### PR TITLE
Fix mutating global item_groups in get_filler_item_name()

### DIFF
--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -643,7 +643,7 @@ class PokemonRedBlueWorld(World):
         if (combined_traps > 0 and
                 self.random.randint(1, 100) <= self.options.trap_percentage.value):
             return self.select_trap()
-        banned_items = item_groups["Unique"]
+        banned_items = item_groups["Unique"].copy()
         if (((not self.options.tea) or "Saffron City" not in [self.fly_map, self.town_map_fly_map])
                 and (not self.options.door_shuffle)):
             # under these conditions, you should never be able to reach the Copycat or Pokémon Tower without being


### PR DESCRIPTION
The `banned_items` variable was the `"Unique"` list within the `item_groups` global. `get_filler_item_name()` could then mutate `banned_items` through `banned_items.append("Poke Doll")` and `banned_items += item_groups["Vending Machine Drinks"]`, causing the contents of the `item_groups` global to be mutated.

This has been fixed by making `banned_items` a shallow copy of `item_groups["Unique"]`.