### PR TITLE
Add Traps to Item Pool

### DIFF
--- a/worlds/sm64ex_spicy/Items.py
+++ b/worlds/sm64ex_spicy/Items.py
@@ -34,6 +34,9 @@ def progression_deprioritized_skip_balancing_if_blocksanity(options):
     if options.blocksanity:
         return ItemClassification.progression_deprioritized_skip_balancing
     return ItemClassification.filler
+    
+def trap(options):
+    return ItemClassification.trap
 
 
 class SM64Item(Item):
@@ -181,6 +184,15 @@ bowser_stage_1up_item_data_table: dict[str, SM64ItemData] = {
     "Bowser Stage Extra 1-Ups": SM64ItemData(sm64ex_base_id + 556, progression_deprioritized),
     "Bowser in the Dark World - Extra 1-Ups": SM64ItemData(sm64ex_base_id + 557, progression_deprioritized),
     "Bowser in the Fire Sea - Extra 1-Ups": SM64ItemData(sm64ex_base_id + 558, progression_deprioritized),
+}
+
+trap_item_data_table: dict[str, SM64ItemData] = {
+    "Bonk Trap": SM64ItemData(sm64ex_base_id + 1760, trap),
+    "Burn Trap": SM64ItemData(sm64ex_base_id + 1761, trap),
+    "Shock Trap": SM64ItemData(sm64ex_base_id + 1762, trap),
+    "Chuckya Trap": SM64ItemData(sm64ex_base_id + 1763, trap),
+    "Spin Trap": SM64ItemData(sm64ex_base_id + 1764, trap),
+    "Gust Trap": SM64ItemData(sm64ex_base_id + 1765, trap),
 }
 
 arbitrary_item_data_table: dict[str, SM64ItemData] = {
@@ -459,7 +471,8 @@ item_data_table = {
     **action_item_data_table,
     **per_level_action_item_data_table,
     **cannon_item_data_table,
-    **painting_unlock_item_data_table
+    **painting_unlock_item_data_table,
+    **trap_item_data_table
 }
 
 item_table = {name: data.code for name, data in item_data_table.items() if data.code is not None}
@@ -484,4 +497,5 @@ item_name_groups: dict[str, set[str]] = {
     "Bowser Stage Extra 1-Up Unlocks": set(bowser_stage_1up_item_data_table),
     "Optional Items": set(optional_item_data_table),
     "Filler": {"1-Up Mushroom"},
+     "Traps": set(trap_item_data_table),
 }

--- a/worlds/sm64ex_spicy/Options.py
+++ b/worlds/sm64ex_spicy/Options.py
@@ -453,6 +453,128 @@ class CombinedProgressiveKeys(DefaultOnToggle):
     """
     display_name = "Combined Progressive Castle Keys"
 
+class TrapsFillerPercentage(NamedRange):
+    """
+    Replaces this percentage of filler items with trap items.
+    Trap types are selected according to their configured weights.
+    It is recommended to keep this at a low percentage so the majority of the pool aren't all traps.
+    """
+    default = 0
+    range_start = 0
+    range_end = 100
+    display_name = "Replace Filler With Traps"
+    special_range_names = {
+        "disabled": 0,
+        "light": 10,
+        "normal": 25,
+        "extreme": 50,
+    }
+
+
+class BonkTrapWeight(Range):
+    """
+    Relative weight for Bonk Traps.
+
+    Higher values make this trap appear more often.
+    A weight of 0 disables this trap.
+    """
+    range_start = 0
+    range_end = 100
+    default = 100
+    display_name = "Bonk Trap Weight"
+
+
+class FireTrapWeight(Range):
+    """
+    Relative weight for Burn Traps.
+
+    Higher values make this trap appear more often.
+    A weight of 0 disables this trap.
+    """
+    range_start = 0
+    range_end = 100
+    default = 100
+    display_name = "Burn Trap Weight"
+
+
+class ElectricTrapWeight(Range):
+    """
+    Relative weight for Shock Traps.
+
+    Higher values make this trap appear more often.
+    A weight of 0 disables this trap.
+    """
+    range_start = 0
+    range_end = 100
+    default = 100
+    display_name = "Shock Trap Weight"
+
+
+class ChuckyaTrapWeight(Range):
+    """
+    Relative weight for Chuckya Traps.
+
+    Higher values make this trap appear more often.
+    A weight of 0 disables this trap.
+    """
+    range_start = 0
+    range_end = 100
+    default = 100
+    display_name = "Chuckya Trap Weight"
+
+
+class SpinTrapWeight(Range):
+    """
+    Relative weight for Spin Traps.
+
+    Higher values make this trap appear more often.
+    A weight of 0 disables this trap.
+    """
+    range_start = 0
+    range_end = 100
+    default = 100
+    display_name = "Spin Trap Weight"
+
+
+class GustTrapWeight(Range):
+    """
+    Relative weight for Gust Traps.
+
+    Higher values make this trap appear more often.
+    A weight of 0 disables this trap.
+    """
+    range_start = 0
+    range_end = 100
+    default = 100
+    display_name = "Gust Trap Weight"
+
+
+trap_weight_options = (
+    BonkTrapWeight,
+    FireTrapWeight,
+    ElectricTrapWeight,
+    ChuckyaTrapWeight,
+    SpinTrapWeight,
+    GustTrapWeight,
+)
+
+trap_weight_option_names = (
+    "bonk_trap_weight",
+    "fire_trap_weight",
+    "electric_trap_weight",
+    "chuckya_trap_weight",
+    "spin_trap_weight",
+    "gust_trap_weight",
+)
+
+trap_item_name_by_option_name = {
+    "bonk_trap_weight": "Bonk Trap",
+    "fire_trap_weight": "Burn Trap",
+    "electric_trap_weight": "Shock Trap",
+    "chuckya_trap_weight": "Chuckya Trap",
+    "spin_trap_weight": "Spin Trap",
+    "gust_trap_weight": "Gust Trap",
+}
 class StrictMoveRequirements(DefaultOnToggle):
     """If disabled, Stars that expect certain moves may have to be acquired without them.
     Only makes a difference for movement abilities that are shuffled."""
@@ -761,6 +883,10 @@ sm64_options_groups = [
         *move_randomizer_options,
         StrictMoveRequirements,
     ]),
+    OptionGroup("Trap Options", [
+        TrapsFillerPercentage,
+        *trap_weight_options,
+    ]),
     OptionGroup("Cosmetic Options", [
         MarioHatColor,
         MarioShirtColor,
@@ -845,5 +971,12 @@ class SM64Options(PerGameCommonOptions):
     bowser_in_the_dark_world_coinsanity_max_coins: BowserInTheDarkWorldCoinsanityMaxCoins
     bowser_in_the_fire_sea_coinsanity_max_coins: BowserInTheFireSeaCoinsanityMaxCoins
     bowser_in_the_sky_coinsanity_max_coins: BowserInTheSkyCoinsanityMaxCoins
+    traps_filler_percentage: TrapsFillerPercentage
+    bonk_trap_weight: BonkTrapWeight
+    fire_trap_weight: FireTrapWeight
+    electric_trap_weight: ElectricTrapWeight
+    chuckya_trap_weight: ChuckyaTrapWeight
+    spin_trap_weight: SpinTrapWeight
+    gust_trap_weight: GustTrapWeight
     death_link: DeathLink
     completion_type: CompletionType

--- a/worlds/sm64ex_spicy/__init__.py
+++ b/worlds/sm64ex_spicy/__init__.py
@@ -12,7 +12,8 @@ from .Locations import location_table, SM64Location, coinsanity_course_data, get
     get_coinsanity_location_names, get_secret_stage_coinsanity_location_names, location_name_groups
 from .Music import build_music_slot_data
 from .Options import sm64_options_groups, SM64Options, coin_star_requirement_option_names, \
-    move_randomizer_option_name_by_action, secret_stage_coinsanity_max_coin_option_names
+    move_randomizer_option_name_by_action, secret_stage_coinsanity_max_coin_option_names, \
+    trap_weight_option_names, trap_item_name_by_option_name
 from .Rules import set_rules
 from .Regions import create_regions, sm64_entrance_to_region, sm64_level_to_entrances, SM64Levels
 from BaseClasses import Item, Tutorial
@@ -115,6 +116,8 @@ class SM64World(World):
         "secret_stage_coinsanity",
         *secret_stage_coinsanity_max_coin_option_names,
         *coin_star_requirement_option_names,
+        "traps_filler_percentage",
+        *trap_weight_option_names,
         "death_link",
         "completion_type",
     )
@@ -392,6 +395,22 @@ class SM64World(World):
         if not self.options.buddy_checks:
             locked_count += len(cannon_item_data_table)
         return locked_count
+        
+    def get_filler_replacements(self, filler_count: int) -> typing.List[str]:
+        replacement_names: typing.List[str] = []
+
+        trap_items = []
+        trap_weights = []
+        for option_name in trap_weight_option_names:
+            weight = getattr(self.options, option_name).value
+            if weight > 0:
+                trap_items.append(trap_item_name_by_option_name[option_name])
+                trap_weights.append(weight)
+
+        trap_count = (filler_count * self.options.traps_filler_percentage.value) // 100
+        if trap_items: replacement_names.extend(self.random.choices(trap_items, weights=trap_weights, k=trap_count,))
+        self.random.shuffle(replacement_names)
+        return replacement_names
 
     def create_items(self):
         item_names = self.get_progression_item_names()
@@ -402,8 +421,11 @@ class SM64World(World):
             raise OptionError(f"{self.player_name}'s Spicy Mycena 64 world has {abs(self.filler_count)} more "
                               f"required items than randomized locations.")
 
+        replacement_item_names = self.get_filler_replacements(self.filler_count)
+        plain_filler_count = self.filler_count - len(replacement_item_names)
         self.multiworld.itempool += [self.create_item(item_name) for item_name in item_names]
-        self.multiworld.itempool += [self.create_item("1-Up Mushroom") for i in range(0, self.filler_count)]
+        self.multiworld.itempool += [self.create_item(item_name) for item_name in replacement_item_names]
+        self.multiworld.itempool += [self.create_item("1-Up Mushroom") for i in range(plain_filler_count)]
 
     def generate_basic(self):
         if not self.options.buddy_checks:


### PR DESCRIPTION
## What is this fixing or adding?
This pull request adds the unused traps located in the sm64ex code to the item pool, using a percentage and weight based system to determine which traps show up.
The traps include the **Bonk Trap**, the **Burn Trap**, the **Shock Trap**, the **Chuckya Trap**, the **Gust Trap** and the **Spin Trap**.

## How was this tested?
This was tested using a locally hosted Archipelago game with the traps set to 50% of the filler item pool.
Session was played until every Trap item had been received, to confirm every Trap was functional as well as confirming it all works.

## If this makes graphical changes, please attach screenshots.
_These were taken using the [Axolotl AP Text Client](https://github.com/mooinglemur/axolotl)._
<img width="1507" height="181" alt="image" src="https://github.com/user-attachments/assets/b59935a8-2a33-4982-94eb-bee30201f925" />
<img width="1303" height="137" alt="image" src="https://github.com/user-attachments/assets/3f90e67a-120f-491e-a2aa-a6c81327b829" />


## Does this require a new build of the Spicy Mycena 64 version of sm64ex?
Actually, no!
This was all tested using the normal Spicy Mycena 64 build.
The only other thing that could be added without changing the build would be adding the Health Pip items into the item pool, however, those served to be rather useless during testing as 99% of the time you are at full HP.