### PR TITLE
Spicy Mycena 64: Fix Logic for 1-Up Blocks and remove Kick from Secrets of the Haunted Books logic

### DIFF
--- a/worlds/sm64ex_spicy/Locations.py
+++ b/worlds/sm64ex_spicy/Locations.py
@@ -691,6 +691,8 @@ one_up_unlock_category_by_location = {
     **{location_name: "Trigger 1-Ups" for location_name in locTrigger1Up_table},
     **{location_name: "Butterflies" for location_name in locButterfly1Up_table},
     **{location_name: "1-Up Blocks" for location_name in loc1UpBlock_table},
+    **{location_name: "1-Up Blocks" for location_name in locBlocksanity_table
+       if location_name.endswith("1-Up Block")},
 }
 
 

--- a/worlds/sm64ex_spicy/LogicTricks.py
+++ b/worlds/sm64ex_spicy/LogicTricks.py
@@ -395,6 +395,24 @@ logic_tricks = {
         "description": "Reaching the second floor by Wall Kicking up to the balcony without the Staircase.",
         "video": "https://www.youtube.com/watch?v=mUrXEnEBiMA",
     },
+    "Big Boo's Haunt Secret of the Haunted Books with Wall Kick": {
+        "internal_id": "logic_bbh_haunted_books_wall_kick",
+        "rule": "WK",
+        "difficulty": "medium",
+        "description": "Reaching the Secret of the Haunted Books by Wall Kicking up from the piano room without the Staircase.",
+    },
+    "Big Boo's Haunt Secret of the Haunted Books with Long Jump & Staircase": {
+        "internal_id": "logic_bbh_haunted_books_long_jump",
+        "rule": "LJ+BBH_STAIRCASE",
+        "difficulty": "easy",
+        "description": "Reaching the Secret of the Haunted Books by Long Jumping from the right side, with Staircase unlocked.",
+    },
+    "Big Boo's Haunt Secret of the Haunted Books with Long Jump & Wall Kick": {
+        "internal_id": "logic_bbh_haunted_books_long_jump_wall_kick",
+        "rule": "LJ+WK",
+        "difficulty": "easy",
+        "description": "Reaching the Secret of the Haunted Books by Wall Kicking up from the piano room without the Staircase, and then Long Jumping from the right.",
+    },
     "Big Boo's Haunt Third Floor with Wall Kick Only": {
         "internal_id": "logic_bbh_third_floor_wall_kick",
         "rule": "WK",

--- a/worlds/sm64ex_spicy/LogicTricks.py
+++ b/worlds/sm64ex_spicy/LogicTricks.py
@@ -395,24 +395,6 @@ logic_tricks = {
         "description": "Reaching the second floor by Wall Kicking up to the balcony without the Staircase.",
         "video": "https://www.youtube.com/watch?v=mUrXEnEBiMA",
     },
-    "Big Boo's Haunt Secret of the Haunted Books with Wall Kick": {
-        "internal_id": "logic_bbh_haunted_books_wall_kick",
-        "rule": "WK",
-        "difficulty": "medium",
-        "description": "Reaching the Secret of the Haunted Books by Wall Kicking up from the piano room without the Staircase.",
-    },
-    "Big Boo's Haunt Secret of the Haunted Books with Long Jump & Staircase": {
-        "internal_id": "logic_bbh_haunted_books_long_jump",
-        "rule": "LJ+BBH_STAIRCASE",
-        "difficulty": "easy",
-        "description": "Reaching the Secret of the Haunted Books by Long Jumping from the right side, with Staircase unlocked.",
-    },
-    "Big Boo's Haunt Secret of the Haunted Books with Long Jump & Wall Kick": {
-        "internal_id": "logic_bbh_haunted_books_long_jump_wall_kick",
-        "rule": "LJ+WK",
-        "difficulty": "easy",
-        "description": "Reaching the Secret of the Haunted Books by Wall Kicking up from the piano room without the Staircase, and then Long Jumping from the right.",
-    },
     "Big Boo's Haunt Third Floor with Wall Kick Only": {
         "internal_id": "logic_bbh_third_floor_wall_kick",
         "rule": "WK",

--- a/worlds/sm64ex_spicy/Rules.py
+++ b/worlds/sm64ex_spicy/Rules.py
@@ -732,7 +732,7 @@ def set_rules(multiworld: MultiWorld, options: SM64Options, player: int, area_co
         "WK+LG | logic_bbh_third_floor_wall_kick | logic_bbh_third_floor_side_flip")
     rf.assign_rule("Big Boo's Haunt - Roof", "LJ | logic_bbh_roof_without_long_jump")
     rf.assign_rule("Big Boo's Haunt - Big Boo's Balcony", "BIG_BOO")
-    rf.assign_rule("Big Boo's Haunt - Secret of the Haunted Books", "BBH_STAIRCASE | logic_bbh_haunted_books_wall_kick | logic_bbh_haunted_books_long_jump | logic_bbh_haunted_books_long_jump_wall_kick")
+    rf.assign_rule("Big Boo's Haunt - Secret of the Haunted Books", "MOVELESS")
     rf.assign_rule("Big Boo's Haunt - Eye to Eye in the Secret Room", "VC & MR_IS")
     rf.assign_rule("Big Boo's Haunt - Shed Roof 1-Up", "TJ/SF/WK")
     # Haze Maze Cave

--- a/worlds/sm64ex_spicy/Rules.py
+++ b/worlds/sm64ex_spicy/Rules.py
@@ -730,9 +730,9 @@ def set_rules(multiworld: MultiWorld, options: SM64Options, player: int, area_co
     rf.assign_rule(
         "Big Boo's Haunt - Third Floor",
         "WK+LG | logic_bbh_third_floor_wall_kick | logic_bbh_third_floor_side_flip")
-    rf.assign_rule("Big Boo's Haunt - Roof", "LJ | logic_bbh_roof_without_long_jump")
+    rf.assign_rule("Big Boo's Haunt - Roof", "LJ | logic_bbh_haunted_books_wall_kick | logic_bbh_haunted_books_long_jump | logic_bbh_haunted_books_long_jump_wall_kick")
     rf.assign_rule("Big Boo's Haunt - Big Boo's Balcony", "BIG_BOO")
-    rf.assign_rule("Big Boo's Haunt - Secret of the Haunted Books", "KK")
+    rf.assign_rule("Big Boo's Haunt - Secret of the Haunted Books", "BBH_STAIRCASE | KK")
     rf.assign_rule("Big Boo's Haunt - Eye to Eye in the Secret Room", "VC & MR_IS")
     rf.assign_rule("Big Boo's Haunt - Shed Roof 1-Up", "TJ/SF/WK")
     # Haze Maze Cave

--- a/worlds/sm64ex_spicy/Rules.py
+++ b/worlds/sm64ex_spicy/Rules.py
@@ -732,7 +732,6 @@ def set_rules(multiworld: MultiWorld, options: SM64Options, player: int, area_co
         "WK+LG | logic_bbh_third_floor_wall_kick | logic_bbh_third_floor_side_flip")
     rf.assign_rule("Big Boo's Haunt - Roof", "LJ | logic_bbh_roof_without_long_jump")
     rf.assign_rule("Big Boo's Haunt - Big Boo's Balcony", "BIG_BOO")
-    rf.assign_rule("Big Boo's Haunt - Secret of the Haunted Books", "MOVELESS")
     rf.assign_rule("Big Boo's Haunt - Eye to Eye in the Secret Room", "VC & MR_IS")
     rf.assign_rule("Big Boo's Haunt - Shed Roof 1-Up", "TJ/SF/WK")
     # Haze Maze Cave

--- a/worlds/sm64ex_spicy/Rules.py
+++ b/worlds/sm64ex_spicy/Rules.py
@@ -729,10 +729,10 @@ def set_rules(multiworld: MultiWorld, options: SM64Options, player: int, area_co
         "BBH_STAIRCASE | logic_bbh_second_floor_wall_kick")
     rf.assign_rule(
         "Big Boo's Haunt - Third Floor",
-        "WK+LG | logic_bbh_third_floor_wall_kick | logic_bbh_third_floor_side_flip")
-    rf.assign_rule("Big Boo's Haunt - Roof", "LJ | logic_bbh_haunted_books_wall_kick | logic_bbh_haunted_books_long_jump | logic_bbh_haunted_books_long_jump_wall_kick")
+        "WK+LG | logic_bbh_third_floor_wall_kick | logic_bbh_third_floor_side_flip") logic_bbh_roof_without_long_jump
+    rf.assign_rule("Big Boo's Haunt - Roof", "LJ | logic_bbh_roof_without_long_jump")
     rf.assign_rule("Big Boo's Haunt - Big Boo's Balcony", "BIG_BOO")
-    rf.assign_rule("Big Boo's Haunt - Secret of the Haunted Books", "BBH_STAIRCASE | KK")
+    rf.assign_rule("Big Boo's Haunt - Secret of the Haunted Books", "BBH_STAIRCASE | logic_bbh_haunted_books_wall_kick | logic_bbh_haunted_books_long_jump | logic_bbh_haunted_books_long_jump_wall_kick")
     rf.assign_rule("Big Boo's Haunt - Eye to Eye in the Secret Room", "VC & MR_IS")
     rf.assign_rule("Big Boo's Haunt - Shed Roof 1-Up", "TJ/SF/WK")
     # Haze Maze Cave

--- a/worlds/sm64ex_spicy/Rules.py
+++ b/worlds/sm64ex_spicy/Rules.py
@@ -729,7 +729,7 @@ def set_rules(multiworld: MultiWorld, options: SM64Options, player: int, area_co
         "BBH_STAIRCASE | logic_bbh_second_floor_wall_kick")
     rf.assign_rule(
         "Big Boo's Haunt - Third Floor",
-        "WK+LG | logic_bbh_third_floor_wall_kick | logic_bbh_third_floor_side_flip") logic_bbh_roof_without_long_jump
+        "WK+LG | logic_bbh_third_floor_wall_kick | logic_bbh_third_floor_side_flip")
     rf.assign_rule("Big Boo's Haunt - Roof", "LJ | logic_bbh_roof_without_long_jump")
     rf.assign_rule("Big Boo's Haunt - Big Boo's Balcony", "BIG_BOO")
     rf.assign_rule("Big Boo's Haunt - Secret of the Haunted Books", "BBH_STAIRCASE | logic_bbh_haunted_books_wall_kick | logic_bbh_haunted_books_long_jump | logic_bbh_haunted_books_long_jump_wall_kick")


### PR DESCRIPTION
## What is this fixing or adding?
This fixes 1-Up Blocks showing up in logic when the player does not have 1-Up Blocks unlocked.

This also fixes the Secrets of the Haunted Books Power Star from requiring Kick (can be done by simply jumping and punching)

## How was this tested?
This was tested by playing till I came across the locations in question.
For the 1-Up Blocks, I played until I unlocked a stage with 1-Up Blocks not unlocked.

For Secrets of the Haunted Books, I was able to get it with only Staircase with little to no effort with no moves unlocked (why did this require Kick?).