### PR TITLE
Spicy Mycena 64: Fix Generation Crash

### DIFF
--- a/worlds/sm64ex_spicy/Rules.py
+++ b/worlds/sm64ex_spicy/Rules.py
@@ -1424,6 +1424,8 @@ class RuleFactory:
         self.world.set_rule(target, rule)
 
     def add_rule(self, target_name: str, rule: Rule) -> None:
+        if target_name in locOneUp_table and not self.options.one_up_checks:
+            return
         combined_rule = self.assigned_rules.get(target_name, True_()) & rule
         self.assigned_rules[target_name] = combined_rule
         target = (


### PR DESCRIPTION
## What is this fixing or adding?
This pull request fixes a generation crash that occurs when 1-Up Unlocks are enabled and 1-Up Checks are set to anything other than "Not Shuffled".

This came up during a fuzz for the Ionium index.

## How was this tested?
Literally just made a YAML with the crashing YAML and it generated fine.

## How high of a priority is this?
Pretty high, its a full on generation crash rather than a logic issue.
Can't think of a reason to ever use this combination of settings, but it's there and must be accounted for,

### The fuzz failure can be found below:
[artifacts.zip](https://github.com/user-attachments/files/30701101/artifacts.zip)
