### PR TITLE
Spicy Mycena 64: Coin Check Types

### DIFF
--- a/worlds/sm64ex_spicy/CoinChecks.py
+++ b/worlds/sm64ex_spicy/CoinChecks.py
@@ -20,11 +20,6 @@ class CoinOutputKind(Enum):
     BLUE = "blue"
 
 
-# Display names used by the Coin Check Types option, in menu order. The color entries (Yellow/Red/Blue
-# Coins) gate non-enemy outputs on CoinOutputDefinition.kind. "Enemy Coins" is a separate bucket: it gates
-# outputs whose is_enemy_source is True (coins that come from defeating or interacting with an enemy)
-# entirely on its own - color does not apply to enemy-sourced coins, so deselecting a color entry never
-# excludes an enemy coin of that color, and deselecting Enemy Coins never excludes a non-enemy coin.
 ENEMY_COIN_CHECK_TYPE_NAME = "Enemy Coins"
 COIN_CHECK_TYPE_NAMES: Mapping[CoinOutputKind, str] = {
     CoinOutputKind.YELLOW: "Yellow Coins",

--- a/worlds/sm64ex_spicy/CoinChecks.py
+++ b/worlds/sm64ex_spicy/CoinChecks.py
@@ -20,7 +20,12 @@ class CoinOutputKind(Enum):
     BLUE = "blue"
 
 
-# Display names used by the Coin Check Types option, in menu order.
+# Display names used by the Coin Check Types option, in menu order. The color entries (Yellow/Red/Blue
+# Coins) gate non-enemy outputs on CoinOutputDefinition.kind. "Enemy Coins" is a separate bucket: it gates
+# outputs whose is_enemy_source is True (coins that come from defeating or interacting with an enemy)
+# entirely on its own - color does not apply to enemy-sourced coins, so deselecting a color entry never
+# excludes an enemy coin of that color, and deselecting Enemy Coins never excludes a non-enemy coin.
+ENEMY_COIN_CHECK_TYPE_NAME = "Enemy Coins"
 COIN_CHECK_TYPE_NAMES: Mapping[CoinOutputKind, str] = {
     CoinOutputKind.YELLOW: "Yellow Coins",
     CoinOutputKind.RED: "Red Coins",
@@ -29,7 +34,7 @@ COIN_CHECK_TYPE_NAMES: Mapping[CoinOutputKind, str] = {
 COIN_CHECK_TYPE_KIND_BY_NAME: Mapping[str, CoinOutputKind] = {
     name: kind for kind, name in COIN_CHECK_TYPE_NAMES.items()
 }
-coin_check_type_option_keys = tuple(COIN_CHECK_TYPE_NAMES.values())
+coin_check_type_option_keys = tuple(COIN_CHECK_TYPE_NAMES.values()) + (ENEMY_COIN_CHECK_TYPE_NAME,)
 
 
 def get_enabled_coin_check_kinds(selected_types: Iterable[str]) -> frozenset[CoinOutputKind]:
@@ -39,6 +44,11 @@ def get_enabled_coin_check_kinds(selected_types: Iterable[str]) -> frozenset[Coi
         for selected_type in selected_types
         if selected_type in COIN_CHECK_TYPE_KIND_BY_NAME
     )
+
+
+def get_enemy_coin_checks_enabled(selected_types: Iterable[str]) -> bool:
+    """Whether the Coin Check Types option allows enemy-sourced coins to become locations."""
+    return ENEMY_COIN_CHECK_TYPE_NAME in selected_types
 
 
 @dataclasses.dataclass(frozen=True, order=True)
@@ -56,6 +66,7 @@ class CoinOutputDefinition:
     kind: CoinOutputKind
     coin_value: int
     source_methods: tuple[str, ...]
+    is_enemy_source: bool = False
 
 
 @dataclasses.dataclass(frozen=True)
@@ -460,12 +471,12 @@ def _build_catalog() -> tuple[CoinSourceDefinition, ...]:
                         CoinOutputDefinition(
                             CoinOutputID(course_name, source_id, index * 2 - 1), course_base + offset,
                             f"{course_name} - {producer_name}, Coin", CoinOutputKind.YELLOW, 1,
-                            (f"{source_id}_yellow",),
+                            (f"{source_id}_yellow",), is_enemy_source=True,
                         ),
                         CoinOutputDefinition(
                             CoinOutputID(course_name, source_id, index * 2), course_base + offset + 1,
                             f"{course_name} - {producer_name}, Blue Coin", CoinOutputKind.BLUE, 5,
-                            (f"{source_id}_blue",),
+                            (f"{source_id}_blue",), is_enemy_source=True,
                         ),
                     ))
                     offset += 2
@@ -473,7 +484,8 @@ def _build_catalog() -> tuple[CoinSourceDefinition, ...]:
                 continue
 
             kind = CoinOutputKind(kind_name)
-            names = _enemy_output_names(source_id, kind, count) or (
+            enemy_names = _enemy_output_names(source_id, kind, count)
+            names = enemy_names or (
                 _standalone_yellow_names(source_id, label, count)
                 if kind is CoinOutputKind.YELLOW and source_id in STANDALONE_YELLOW_COIN_SOURCE_IDS
                 else _output_names(label, kind, count)
@@ -485,6 +497,7 @@ def _build_catalog() -> tuple[CoinSourceDefinition, ...]:
                     f"{course_name} - {name}", kind, value,
                     COIN_OUTPUT_SOURCE_METHOD_OVERRIDES.get(
                         (course_name, source_id, index), (source_id,)),
+                    is_enemy_source=enemy_names is not None,
                 )
                 for index, name in enumerate(names, 1)
             )
@@ -552,11 +565,15 @@ def select_individual_coin_outputs(
         catalog: Iterable[CoinOutputDefinition] = coin_output_catalog,
         excluded_output_ids: frozenset[CoinOutputID] = frozenset(),
         allowed_kinds: frozenset[CoinOutputKind] | None = None,
+        allow_enemy_sources: bool = True,
 ) -> tuple[CoinOutputDefinition, ...]:
     """Select the requested percentage independently within each course.
 
-    allowed_kinds restricts which CoinOutputKinds (yellow, red, blue) are eligible to become
-    locations. None (the default) allows every kind, matching prior behavior.
+    Every output is gated by exactly one of two filters, based on is_enemy_source:
+      - Non-enemy outputs are gated by allowed_kinds (yellow, red, blue). None (the default) allows
+        every kind, matching prior behavior.
+      - Enemy-sourced outputs (coins that come from defeating or interacting with an enemy) are gated
+        solely by allow_enemy_sources, regardless of their color - allowed_kinds does not apply to them.
     """
     if not 0 <= percentage <= 100:
         raise ValueError("Coin Checks percentage must be between 0 and 100")
@@ -564,7 +581,10 @@ def select_individual_coin_outputs(
     for output in catalog:
         if output.output_id in excluded_output_ids:
             continue
-        if allowed_kinds is not None and output.kind not in allowed_kinds:
+        if output.is_enemy_source:
+            if not allow_enemy_sources:
+                continue
+        elif allowed_kinds is not None and output.kind not in allowed_kinds:
             continue
         by_course[output.output_id.course_name].append(output)
     selected = []

--- a/worlds/sm64ex_spicy/CoinChecks.py
+++ b/worlds/sm64ex_spicy/CoinChecks.py
@@ -20,6 +20,27 @@ class CoinOutputKind(Enum):
     BLUE = "blue"
 
 
+# Display names used by the Coin Check Types option, in menu order.
+COIN_CHECK_TYPE_NAMES: Mapping[CoinOutputKind, str] = {
+    CoinOutputKind.YELLOW: "Yellow Coins",
+    CoinOutputKind.RED: "Red Coins",
+    CoinOutputKind.BLUE: "Blue Coins",
+}
+COIN_CHECK_TYPE_KIND_BY_NAME: Mapping[str, CoinOutputKind] = {
+    name: kind for kind, name in COIN_CHECK_TYPE_NAMES.items()
+}
+coin_check_type_option_keys = tuple(COIN_CHECK_TYPE_NAMES.values())
+
+
+def get_enabled_coin_check_kinds(selected_types: Iterable[str]) -> frozenset[CoinOutputKind]:
+    """Map the Coin Check Types option value to the CoinOutputKinds it allows as locations."""
+    return frozenset(
+        COIN_CHECK_TYPE_KIND_BY_NAME[selected_type]
+        for selected_type in selected_types
+        if selected_type in COIN_CHECK_TYPE_KIND_BY_NAME
+    )
+
+
 @dataclasses.dataclass(frozen=True, order=True)
 class CoinOutputID:
     course_name: str
@@ -530,13 +551,20 @@ def select_individual_coin_outputs(
         percentage: int, rng: random.Random,
         catalog: Iterable[CoinOutputDefinition] = coin_output_catalog,
         excluded_output_ids: frozenset[CoinOutputID] = frozenset(),
+        allowed_kinds: frozenset[CoinOutputKind] | None = None,
 ) -> tuple[CoinOutputDefinition, ...]:
-    """Select the requested percentage independently within each course."""
+    """Select the requested percentage independently within each course.
+
+    allowed_kinds restricts which CoinOutputKinds (yellow, red, blue) are eligible to become
+    locations. None (the default) allows every kind, matching prior behavior.
+    """
     if not 0 <= percentage <= 100:
         raise ValueError("Coin Checks percentage must be between 0 and 100")
     by_course: dict[str, list[CoinOutputDefinition]] = defaultdict(list)
     for output in catalog:
         if output.output_id in excluded_output_ids:
+            continue
+        if allowed_kinds is not None and output.kind not in allowed_kinds:
             continue
         by_course[output.output_id.course_name].append(output)
     selected = []

--- a/worlds/sm64ex_spicy/Options.py
+++ b/worlds/sm64ex_spicy/Options.py
@@ -3,6 +3,7 @@ from Options import DefaultOnToggle, Range, Toggle, DeathLink, Choice, PerGameCo
     OptionSet, ItemsAccessibility
 
 from .LogicTricks import logic_trick_option_keys
+from .CoinChecks import coin_check_type_option_keys
 
 
 class CoinStarRequirement(Range):
@@ -46,6 +47,14 @@ class CoinChecks(Range):
     range_start = 0
     range_end = 100
     default = 0
+
+
+class CoinCheckTypes(OptionSet):
+    """Choose which coin types are allowed to become Coin Checks locations.
+    Options are Yellow Coins, Red Coins and Blue Coins."""
+    display_name = "Coin Check Types"
+    valid_keys = coin_check_type_option_keys
+    default = frozenset(coin_check_type_option_keys)
 
 
 class SM64Accessibility(ItemsAccessibility):
@@ -1103,6 +1112,7 @@ sm64_options_groups = [
         BowserStage1Ups,
     ]),
     OptionGroup("Coin Options", [
+        CoinCheckTypes,
         CoinChecks,
         CoinCountChecks,
         *secret_stage_coin_count_max_coin_options,
@@ -1186,6 +1196,7 @@ class SM64Options(PerGameCommonOptions):
     music_shuffle: MusicShuffle
     skybox_shuffle: SkyboxShuffle
     coin_checks: CoinChecks
+    coin_check_types: CoinCheckTypes
     coin_count_checks: CoinCountChecks
     bob_omb_battlefield_coin_star_requirement: BobOmbBattlefieldCoinStarRequirement
     whomps_fortress_coin_star_requirement: WhompsFortressCoinStarRequirement

--- a/worlds/sm64ex_spicy/Options.py
+++ b/worlds/sm64ex_spicy/Options.py
@@ -51,7 +51,10 @@ class CoinChecks(Range):
 
 class CoinCheckTypes(OptionSet):
     """Choose which coin types are allowed to become Coin Checks locations.
-    Options are Yellow Coins, Red Coins and Blue Coins."""
+    Yellow Coins: Every yellow coin in a stage can be a location
+    Red Coins: Every red coin in a stage can be a location
+    Blue Coins: Every blue coin in a stage can be a location
+    Enemy Coins: Every coin from an enemy can be a location"""
     display_name = "Coin Check Types"
     valid_keys = coin_check_type_option_keys
     default = frozenset(coin_check_type_option_keys)

--- a/worlds/sm64ex_spicy/__init__.py
+++ b/worlds/sm64ex_spicy/__init__.py
@@ -20,7 +20,7 @@ from .Items import item_data_table, action_item_data_table, cannon_item_data_tab
 from .Locations import location_table, SM64Location, coin_count_check_course_data, get_coin_count_check_location_name, \
     get_coin_count_check_location_names, get_secret_stage_coin_count_check_location_names, location_name_groups
 from .CoinChecks import CoinOutputID, coin_output_by_name, select_individual_coin_outputs, \
-    get_enabled_coin_check_kinds
+    get_enabled_coin_check_kinds, get_enemy_coin_checks_enabled
 from .Music import build_music_slot_data
 from .Options import sm64_options_groups, SM64Options, coin_star_requirement_option_names, \
     move_randomizer_option_name_by_action, secret_stage_coin_count_max_coin_option_names, \
@@ -250,6 +250,7 @@ class SM64World(World):
                 self.random,
                 excluded_output_ids=frozenset(excluded_coin_outputs),
                 allowed_kinds=get_enabled_coin_check_kinds(self.options.coin_check_types.value),
+                allow_enemy_sources=get_enemy_coin_checks_enabled(self.options.coin_check_types.value),
             )
             self.coin_check_location_names = tuple(
                 output.location_name for output in selected_coin_outputs

--- a/worlds/sm64ex_spicy/__init__.py
+++ b/worlds/sm64ex_spicy/__init__.py
@@ -19,7 +19,8 @@ from .Items import item_data_table, action_item_data_table, cannon_item_data_tab
     per_level_sign_unlock_item_data_table, sign_unlock_item_names, progressive_cap_length_item_names
 from .Locations import location_table, SM64Location, coin_count_check_course_data, get_coin_count_check_location_name, \
     get_coin_count_check_location_names, get_secret_stage_coin_count_check_location_names, location_name_groups
-from .CoinChecks import CoinOutputID, coin_output_by_name, select_individual_coin_outputs
+from .CoinChecks import CoinOutputID, coin_output_by_name, select_individual_coin_outputs, \
+    get_enabled_coin_check_kinds
 from .Music import build_music_slot_data
 from .Options import sm64_options_groups, SM64Options, coin_star_requirement_option_names, \
     move_randomizer_option_name_by_action, secret_stage_coin_count_max_coin_option_names, \
@@ -173,6 +174,7 @@ class SM64World(World):
         "music_shuffle",
         "skybox_shuffle",
         "coin_checks",
+        "coin_check_types",
         "coin_count_checks",
         *secret_stage_coin_count_max_coin_option_names,
         *coin_star_requirement_option_names,
@@ -247,6 +249,7 @@ class SM64World(World):
                 self.options.coin_checks.value,
                 self.random,
                 excluded_output_ids=frozenset(excluded_coin_outputs),
+                allowed_kinds=get_enabled_coin_check_kinds(self.options.coin_check_types.value),
             )
             self.coin_check_location_names = tuple(
                 output.location_name for output in selected_coin_outputs


### PR DESCRIPTION
## What is this fixing or adding?
This adds a new option to go alongside the Coin Checks option, which allows you to choose which coin types are added as locations.

## How was this tested?
I set it to Red Coins and Blue Coins with Coin Checks at 100, then just generated and looked at the spoiler log.
I then genned with only Enemy Coins and once again checked the spoiler log.

## Why?
What if you wanted only specific types of coins to be checks?
Like, making every single individual coin a check is cool and all, but what if you only want all of specific types?
With this new setting you can!

Some combinations are only Red Coins, non Yellow coins, and just Enemy Coins (pseudo Enemysanity)