### PR TITLE
Add BOB chain chomp with cork box trick

### DIFF
--- a/worlds/sm64ex_spicy/LogicTricks.py
+++ b/worlds/sm64ex_spicy/LogicTricks.py
@@ -232,7 +232,7 @@ logic_tricks = {
     "Bob-omb Battlefield Chain Chomp Gate with Throwable Cork Box Clip": {
         "internal_id": "logic_bob_chain_chomp_gate_with_cork_box",
         "rule": "BOB_CORKBOXES",
-        "difficulty": "medium",
+        "difficulty": "hard",
         "description": "Collecting Behind Chain Chomp's Gate without Ground Pound, using a Throwable Cork Box"
                        "to clip through the gate.",
         "video": "https://www.youtube.com/watch?v=Ta6Hj2F2slo"

--- a/worlds/sm64ex_spicy/LogicTricks.py
+++ b/worlds/sm64ex_spicy/LogicTricks.py
@@ -229,6 +229,14 @@ logic_tricks = {
                        "the gate.",
         "video": "https://www.youtube.com/watch?v=-dZKkhB30LY"
     },
+    "Bob-omb Battlefield Chain Chomp Gate with Throwable Cork Box Clip": {
+        "internal_id": "logic_bob_chain_chomp_gate_with_cork_box",
+        "rule": "BOB_CORKBOXES",
+        "difficulty": "medium",
+        "description": "Collecting Behind Chain Chomp's Gate without Ground Pound, using a Throwable Cork Box"
+                       "to clip through the gate.",
+        "video": "https://www.youtube.com/watch?v=Ta6Hj2F2slo"
+    },
     # Whomp's Fortress
     "Whomp's Fortress Caged Island from the Floating Island with Triple Jump Off of Whomp King": {
         "internal_id": "logic_wf_caged_island_cage_triple_jump",

--- a/worlds/sm64ex_spicy/Rules.py
+++ b/worlds/sm64ex_spicy/Rules.py
@@ -863,7 +863,8 @@ def set_rules(multiworld: MultiWorld, options: SM64Options, player: int, area_co
             action_item_names=rf.get_action_item_names("Bob-omb Battlefield")))
     rf.assign_rule("Bob-omb Battlefield - Behind Chain Chomp's Gate",
                    "CHAIN_CHOMP & WOODEN_POSTS & GP | "
-                   "CHAIN_CHOMP & logic_bob_chain_chomp_gate_without_ground_pound")
+                   "CHAIN_CHOMP & logic_bob_chain_chomp_gate_without_ground_pound | "
+                   "CHAIN_CHOMP & logic_bob_chain_chomp_gate_with_cork_box")
     rf.assign_rule("Bob-omb Battlefield - Bob-omb Buddy", "BOB_BUDDY")
     rf.assign_rule("Bob-omb Battlefield - Cannon Tree 1-Up", "CL/TJ/BF/SF")
     # Whomp's Fortress
@@ -1899,6 +1900,7 @@ class RuleFactory:
             self.options, "enemy_unlocks",
             f"{level_name} - Flying Bookends", f"{level_name} - Flying Bookends")
         item_names["JRB_SIGNS"] = HasUnlock("Signs", "Jolly Roger Bay - Signs")
+        item_names["BOB_CORKBOXES"] = HasUnlock("Throwable Cork Boxes", "Bob-omb Battlefield - Throwable Cork Boxes")
         return item_names
 
     def get_action_item_names(self, target_name: str) -> dict[str, str | bool]:

--- a/worlds/sm64ex_spicy/test/locations/test_bob_omb_battlefield.py
+++ b/worlds/sm64ex_spicy/test/locations/test_bob_omb_battlefield.py
@@ -178,7 +178,10 @@ class TestBobOmbBattlefieldChainChompTrick(SM64TestBase):
     run_default_tests = False
     options = {
         **BOB_OPTIONS,
-        "logic_tricks": {"Bob-omb Battlefield Chain Chomp Gate with Bob-omb Clip"},
+        "logic_tricks": {
+            "Bob-omb Battlefield Chain Chomp Gate with Bob-omb Clip",
+            "Bob-omb Battlefield Chain Chomp Gate with Throwable Cork Box Clip"
+        },
     }
 
     def test_chain_chomp_gate_with_bob_omb(self):
@@ -188,4 +191,13 @@ class TestBobOmbBattlefieldChainChompTrick(SM64TestBase):
              ["Bob-omb Battlefield - Bob-ombs"]],
             ["Bob-omb Battlefield - Behind Chain Chomp's Gate", True,
              ["Bob-omb Battlefield - Chain Chomp", "Bob-omb Battlefield - Bob-ombs"]],
+        ], starting_regions=["Bob-omb Battlefield"])
+
+    def test_chain_chomp_gate_with_cork_box(self):
+        self.run_location_tests([
+            ["Bob-omb Battlefield - Behind Chain Chomp's Gate", False, []],
+            ["Bob-omb Battlefield - Behind Chain Chomp's Gate", False,
+             ["Bob-omb Battlefield - Throwable Cork Boxes"]],
+            ["Bob-omb Battlefield - Behind Chain Chomp's Gate", True,
+             ["Bob-omb Battlefield - Chain Chomp", "Bob-omb Battlefield - Throwable Cork Boxes"]],
         ], starting_regions=["Bob-omb Battlefield"])

--- a/worlds/sm64ex_spicy/test/test_access.py
+++ b/worlds/sm64ex_spicy/test/test_access.py
@@ -523,6 +523,10 @@ class BobOmbBattlefieldMediumLogicTricksTestBase(SM64TestBase):
         self.collect(self.get_item_by_name("Bob-omb Battlefield - Cannon Unlock"))
         self.assertTrue(self.can_reach_location("Bob-omb Battlefield - Mario Wings to the Sky"))
 
+    def test_chain_chomp_with_cork_box(self):
+        self.collect(self.get_item_by_name("Bob-omb Battlefield - Throwable Cork Boxes"))
+        self.assertTrue(self.can_reach_location("Bob-omb Battlefield - Behind Chain Chomp's Gate"))
+
 
 class BobOmbBattlefieldHardLogicTricksTestBase(SM64TestBase):
     run_default_tests = False


### PR DESCRIPTION
Add a logic trick that allows collecting `Behind Chain Chomp's Gate` using a cork box to clip through the gate. 

The video is old and low quality, but shows the trick quite well. I can try to record a high-quality one if necessary.

Also, this is my first time contributing to any apworld, so I'm not 100% sure I've got the logic right.

EDIT: Writing the tests for this made me realize the chain chomp requirement might be unnecessary, but the bob-omb clip had it too. I don't know how to properly test it in game.