### PR TITLE
Fix video for WF Into the Wild Blue moveless

### DIFF
--- a/worlds/sm64ex_spicy/LogicTricks.py
+++ b/worlds/sm64ex_spicy/LogicTricks.py
@@ -319,7 +319,7 @@ logic_tricks = {
         "rule": "",
         "difficulty": "hard",
         "description": "Reaching Shoot Into the Wild Blue with a jump.",
-        "video": "https://www.youtube.com/watch?v=E7qv8EsIr5E"
+        "video": "https://www.youtube.com/watch?v=d3i77JAY6ms"
     },
     # Jolly Roger Bay
     "Jolly Roger Bay Upper Platform with Ledge Grab": {


### PR DESCRIPTION
Video link for that trick was for the long jump version, replaced it with the moveless one.